### PR TITLE
Fix return path in PrismPublicKey.Decompress

### DIFF
--- a/OpenPrismNode.Core/Models/PrismPublicKey.cs
+++ b/OpenPrismNode.Core/Models/PrismPublicKey.cs
@@ -58,9 +58,9 @@ public class PrismPublicKey
 
     public static Result<(byte[], byte[])> Decompress(byte[] compressedEcKeyData, string curve)
     {
-        if (curve != "secp256k1")
+        if (curve != PrismParameters.Secp256k1CurveName)
         {
-            Result.Fail("Only secp256k1 is supported");
+            return Result.Fail<(byte[], byte[])>("Only secp256k1 is supported");
         }
 
         try


### PR DESCRIPTION
## Summary
- ensure `Decompress` aborts for unsupported curves

## Testing
- `dotnet test` *(fails: `dotnet` not found)*